### PR TITLE
feat: added a magicball for community

### DIFF
--- a/src/bot/commands/8ball.ts
+++ b/src/bot/commands/8ball.ts
@@ -1,0 +1,19 @@
+import Discord from 'discord.js';
+
+import ICommand from './ICommand';
+
+const command: ICommand = {
+  name: '8ball',
+  aliases: ['eightball', 'magicball', 'ball', 'wisdomball'],
+  description: 'Ask the magic eightball for advice!',
+  async execute(message: Discord.Message, args: string[]) {
+      const responses = ["as I see it, yes.", "err, ask again later.", "better not tell you now.", "that's hard to predict right now.",
+        "concentrate... and ask again.", "don't count on it.", "it is certain.", "it is decidedly so.", "most likely.", "no.",
+        "likely not.", "my sources say no.", "hmm, outlook not so good.", "outlook is good.", "not sure, try again.",
+        "as dubealex commands it: maybe!", "googliano'd the answer and uh, it's a yes?", "careful, but yes",
+        "signs point to yes.", "very doubtful.", "without a doubt.","yes.", "yes - definitely.", "yeah, you can rely on it."];
+        message.reply(responses[Math.floor(Math.random() * responses.length)]);
+  },
+};
+
+export default command;

--- a/src/bot/commands/index.ts
+++ b/src/bot/commands/index.ts
@@ -1,9 +1,11 @@
 import help from './help';
 import ping from './ping';
 import see from './see';
+import magicball from './8ball';
 
 export default [
   help,
   ping,
-  see
+  see,
+  magicball
 ]


### PR DESCRIPTION
## Context

N/A

## Description

It adds a couple of commands to enable community members asking simple questions that will be met with a random response. The response is an unorganized list of yes/no/maybe type answers that will be picked from. 

The command will not parse the actual question so a non-question or an empty command will still be met with a response at this point.

## Dependencies

None

## Testing

Tested the command with various questions in a seperate server where the bot lives. It has responded with a variety of responses.
