### PR TITLE
[Mongo]: Add MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ At a minimum you need to provide the Discord bots Token, which can be found on t
 | DISCORD_BOT_TOKEN | Discord bots Token
 | NODE_ENV          | What environment the bot is running in | `production`, `development` or `test` |
 | LOG_LEVEL         | What level of logs should be displayed in console | `error`, `warn`, `info`, `verbose`, `debug` or `silly` |
+| MONGODB_URI | Full connection string for MongoDB database, include db_name if user is scoped to single database | mongodb://user:password@localhost:27017/venom_db |
+| MONGODB_DB_NAME | The name of the database to use for this project | venom_db |
 
 ### Bot commands
 

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "discord.js": "~12.2.0",
     "dotenv": "~8.2.0",
     "inversify": "~5.0.1",
-    "mongoose": "~5.9.28",
+    "mongodb": "~3.6.0",
     "reflect-metadata": "~0.1.13",
     "winston": "~3.3.3"
   },
   "devDependencies": {
     "@types/dotenv": "~8.2.0",
-    "@types/mongoose": "~5.7.36",
+    "@types/mongodb": "~3.5.25",
     "@types/node": "~14.0.27",
     "@types/winston": "~2.4.4",
     "nodemon": "~2.0.4",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "discord.js": "~12.2.0",
     "dotenv": "~8.2.0",
     "inversify": "~5.0.1",
+    "mongoose": "~5.9.28",
     "reflect-metadata": "~0.1.13",
     "winston": "~3.3.3"
   },
   "devDependencies": {
     "@types/dotenv": "~8.2.0",
+    "@types/mongoose": "~5.7.36",
     "@types/node": "~14.0.27",
     "@types/winston": "~2.4.4",
     "nodemon": "~2.0.4",

--- a/src/.env.template
+++ b/src/.env.template
@@ -1,5 +1,6 @@
 BOT_TRIGGER=!
 DISCORD_BOT_TOKEN=[replace with own token]
 MONGODB_URI=[mongo_connection_string]
+MONGODB_DB_NAME=[mongo_db_name]
 NODE_ENV=production
 LOG_LEVEL=error

--- a/src/.env.template
+++ b/src/.env.template
@@ -1,4 +1,5 @@
 BOT_TRIGGER=!
 DISCORD_BOT_TOKEN=[replace with own token]
+MONGODB_URI=[mongo_connection_string]
 NODE_ENV=production
 LOG_LEVEL=error

--- a/src/bot/commands/ICommand.ts
+++ b/src/bot/commands/ICommand.ts
@@ -1,8 +1,9 @@
 import Discord, { Collection } from 'discord.js';
+import MongoService from 'src/core/services/mongo.service';
 
 export default interface ICommand {
   name: string;
   aliases?: string[];
   description: string;
-  execute: (message: Discord.Message, args: string[], prefix?: string, commands?: Collection<string, ICommand>) => Promise<void>,
+  execute: (message: Discord.Message, args: string[], prefix?: string, commands?: Collection<string, ICommand>, dbService?: MongoService) => Promise<any>,
 }

--- a/src/bot/commands/ICommand.ts
+++ b/src/bot/commands/ICommand.ts
@@ -5,5 +5,6 @@ export default interface ICommand {
   name: string;
   aliases?: string[];
   description: string;
+  example?: string;
   execute: (message: Discord.Message, args: string[], prefix?: string, commands?: Collection<string, ICommand>, dbService?: MongoService) => Promise<any>,
 }

--- a/src/bot/commands/addgreeting.ts
+++ b/src/bot/commands/addgreeting.ts
@@ -1,0 +1,49 @@
+import Discord, { Collection } from 'discord.js';
+
+import MongoService from '../../core/services/mongo.service';
+
+import ICommand from './ICommand';
+
+const command: ICommand = {
+  name: 'addgreeting',
+  aliases: ['ag'],
+  description: 'Adds a string to the list greetings used when new users connect to server!',
+  async execute(message: Discord.Message, args: string[], prefix?: string, commands?: Collection<string, ICommand>, dbService?: MongoService) {
+    let isPermitted = false;
+    const permittedRoles = ['bot-devs', 'admin', 'staff']
+
+    message.guild.roles.cache.forEach(r => {
+      if (permittedRoles.indexOf(r.name) !== -1) {
+        isPermitted = true;
+      }
+    })
+
+    // Only certain users can use this command
+    // TODO: Better handling of permissions for commands in a generic way
+    if (!isPermitted) {
+      return message.reply('Sorry but I can\'t let you add greetings!');
+    }
+
+    // Can't do much without a message
+    if (args.length === 0) {
+      return message.author.send('When adding a greeting you need to also provide a message!');
+    }
+
+    // Check for dupes
+    const greetingStr = args.join(' ');
+    const matchedMessages = await dbService.find(message.author.id, 'greetings', { message: greetingStr });
+    if (matchedMessages.length > 0) {
+      return message.author.send('That greeting has already been added!');
+    }
+
+    const result = await dbService.insert(message.author.id, 'greetings', [{ message: greetingStr }]);
+
+    if (!result) {
+      message.author.send('Uh-oh! Couldn\'t add that greeting!');
+    }
+
+    message.author.send('I\'ve added the greeting you told me about!');
+  },
+};
+
+export default command;

--- a/src/bot/commands/addgreeting.ts
+++ b/src/bot/commands/addgreeting.ts
@@ -1,13 +1,19 @@
 import Discord, { Collection } from 'discord.js';
 
 import MongoService from '../../core/services/mongo.service';
+import ConfigService from '../../core/services/config.service'
+
+import container from '../../inversity.config';
 
 import ICommand from './ICommand';
+
+const prefix = container.resolve<ConfigService>(ConfigService).get('BOT_TRIGGER');
 
 const command: ICommand = {
   name: 'addgreeting',
   aliases: ['ag'],
-  description: 'Adds a string to the list greetings used when new users connect to server!',
+  description: 'Adds a string to the list greetings used when new users connect to server! Include `{name}` in your message to replace with the new users name.',
+  example: `\`${prefix}addgreeting Welcome to the club {name}\``,
   async execute(message: Discord.Message, args: string[], prefix?: string, commands?: Collection<string, ICommand>, dbService?: MongoService) {
     let isPermitted = false;
     const permittedRoles = ['bot-devs', 'admin', 'staff']

--- a/src/bot/commands/addgreeting.ts
+++ b/src/bot/commands/addgreeting.ts
@@ -15,19 +15,13 @@ const command: ICommand = {
   description: 'Adds a string to the list greetings used when new users connect to server! Include `{name}` in your message to replace with the new users name.',
   example: `\`${prefix}addgreeting Welcome to the club {name}\``,
   async execute(message: Discord.Message, args: string[], prefix?: string, commands?: Collection<string, ICommand>, dbService?: MongoService) {
-    let isPermitted = false;
-    const permittedRoles = ['bot-devs', 'admin', 'staff']
-
-    message.guild.roles.cache.forEach(r => {
-      if (permittedRoles.indexOf(r.name) !== -1) {
-        isPermitted = true;
-      }
-    })
-
     // Only certain users can use this command
     // TODO: Better handling of permissions for commands in a generic way
+    const permittedRoles = ['staff']
+    const isPermitted = message.member.roles.cache.some(r => permittedRoles.indexOf(r.name) !== -1);
+
     if (!isPermitted) {
-      return message.reply('Sorry but I can\'t let you add greetings!');
+      return message.author.send('Sorry but I can\'t let you add greetings!');
     }
 
     // Can't do much without a message

--- a/src/bot/commands/index.ts
+++ b/src/bot/commands/index.ts
@@ -2,10 +2,12 @@ import help from './help';
 import ping from './ping';
 import see from './see';
 import magicball from './8ball';
+import addgreeting from './addgreeting'
 
 export default [
   help,
   ping,
   see,
-  magicball
+  magicball,
+  addgreeting
 ]

--- a/src/core/services/config.service.ts
+++ b/src/core/services/config.service.ts
@@ -34,6 +34,7 @@ export default class ConfigService {
       BOT_TRIGGER: process.env.BOT_TRIGGER || '!',
       DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN,
       MONGODB_URI: process.env.MONGODB_URI || '',
+      MONGODB_DB_NAME: process.env.MONGODB_DB_NAME || '',
       ENVIRONMENT: (process.env.NODE_ENV as Environment) || 'development',
       LOG_LEVEL: (process.env.LOG_LEVEL as LogLevel) || 'info',
     };

--- a/src/core/services/config.service.ts
+++ b/src/core/services/config.service.ts
@@ -33,6 +33,7 @@ export default class ConfigService {
     this.config = {
       BOT_TRIGGER: process.env.BOT_TRIGGER || '!',
       DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN,
+      MONGODB_URI: process.env.MONGODB_URI || '',
       ENVIRONMENT: (process.env.NODE_ENV as Environment) || 'development',
       LOG_LEVEL: (process.env.LOG_LEVEL as LogLevel) || 'info',
     };

--- a/src/core/services/mongo.service.ts
+++ b/src/core/services/mongo.service.ts
@@ -85,7 +85,7 @@ export default class MongoService {
    *
    * @returns Returns matched document
    *
-   * @example findOne('123456', 'collectionName', { key: 'value' })
+   * @example find('123456', 'collectionName', { key: 'value' })
    */
   public async find(userId: string, collection: string, query: any) {
     try {

--- a/src/core/services/mongo.service.ts
+++ b/src/core/services/mongo.service.ts
@@ -1,0 +1,243 @@
+import mongodb from 'mongodb';
+import { injectable } from "inversify";
+import assert from 'assert';
+
+import container from '../../inversity.config';
+
+import ConfigService from './config.service';
+import LoggerService from './logger.service';
+
+@injectable()
+export default class MongoService {
+  private _configService: ConfigService = container.resolve<ConfigService>(ConfigService);
+  private _loggerService: LoggerService = container.resolve<LoggerService>(LoggerService);
+
+  private _mongoClient: mongodb.MongoClient;
+  public _db: mongodb.Db;
+
+  public async connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this._mongoClient = new mongodb.MongoClient(this._configService.get('MONGODB_URI'), { useUnifiedTopology: true });
+
+      this._mongoClient.connect((err) => {
+        if (err) {
+          this._loggerService.log('error', 'Venom could not connect to MongoDB', err);
+          reject();
+        } else {
+          this._loggerService.log('info', 'Venom is connected to MongoDB');
+
+          this._db = this._mongoClient.db(this._configService.get('MONGODB_DB_NAME'));
+
+          resolve();
+        }
+      });
+    });
+  }
+
+  public disconnect() {
+    if (this._mongoClient && this._mongoClient.isConnected) {
+      this._loggerService.log('info', 'Closing connection to MongoDB');
+      this._mongoClient.close();
+    }
+  }
+
+  /**
+   * Fetches the first document that matches the query
+   *
+   * @param collection String identifier for collection document belongs to
+   * @param query key/value pairs of search conditions
+   *
+   * @returns Returns matched document
+   *
+   * @example findOne('123456', 'collectionName', { ident: 'generated-slug' })
+   */
+  public async findOne(userId: string, collection: string, query: any) {
+    try {
+      this.verifyConnection();
+
+      const resp = await this._db.collection(collection).findOne(query);
+
+      this._loggerService.log('verbose', 'Fetched single document from MongoDB', {
+        userId,
+        collection,
+        query,
+        resp,
+      });
+
+      return resp;
+    } catch (err) {
+      this._loggerService.log('error', 'Could not find document', {
+        userId,
+        error: err,
+        collection,
+        query,
+      });
+
+      return false;
+    }
+  }
+
+  /**
+   * Fetches all documents that match the query
+   *
+   * @param collection String identifier for collection documents belong to
+   * @param query key/value pairs of search conditions
+   *
+   * @returns Returns matched document
+   *
+   * @example findOne('123456', 'collectionName', { key: 'value' })
+   */
+  public async find(userId: string, collection: string, query: any) {
+    try {
+      this.verifyConnection();
+
+      const resp = await this._db.collection(collection).find(query).toArray();
+
+      this._loggerService.log('verbose', 'Fetched documents matching query from MongoDB', {
+        userId,
+        collection,
+        query,
+        resp,
+      });
+
+      return resp;
+    } catch (err) {
+      this._loggerService.log('error', 'Could not find documents', {
+        userId,
+        error: err,
+        collection,
+        query,
+      });
+
+      return [];
+    }
+  }
+
+  /**
+   * Adds one or more documents to given collection
+   *
+   * @param collection String identifier for collection document is to be stored again
+   * @param payload Array of objects containing the key/value pairs to be stored
+   *
+   * @returns Returns true for successful insert
+   *
+   * @example `insert('123456', 'collectionName', [{ body: 'This is a document!' }])`
+   */
+  public async insert(userId: string, collection: string, payload: any[]) {
+    try {
+      this.verifyConnection();
+
+      const resp = await this._db.collection(collection).insert(payload);
+
+      if (resp.result.ok !== 1 || resp.insertedCount !== payload.length) {
+        throw new Error(JSON.stringify(resp));
+      }
+
+      this._loggerService.log('verbose', `Inserted ${resp.insertedCount} documents into ${collection}`, {
+        userId,
+        collection,
+        payload,
+        resp
+      });
+
+      return true;
+    } catch (err) {
+      this._loggerService.log('error', 'Could not insert documents to database', {
+        userId,
+        error: err,
+        collection,
+        payload
+      });
+
+      return false;
+    }
+  }
+
+  /**
+   * Update single document from MongoDB
+   *
+   * @param collection String identifier for collection documents belong to
+   * @param query key/value pairs of search conditions
+   * @param payload Objects containing the key/value pairs to be stored against existing documents
+   *
+   * @returns Returns true for successful update
+   *
+   * @example `updateMany('123456', 'collectionName', { ident: 'generated-slug' }, { secondKey: 'new data'})`
+   */
+  public async updateMany(userId: string, collection: string, query: any, payload: any) {
+    try {
+      this.verifyConnection();
+
+      const resp = await this._db.collection(collection).updateMany(query, { $set: payload });
+
+      if (resp.result.ok !== 1) {
+        throw new Error(JSON.stringify(resp));
+      }
+
+      this._loggerService.log('verbose', `Updated documents into ${collection} with id ${resp.upsertedId}`, {
+        userId,
+        collection,
+        query,
+        payload,
+        resp
+      });
+
+      return true;
+    } catch (err) {
+      this._loggerService.log('error', 'Could not update documents', {
+        userId,
+        collection,
+        query,
+        payload,
+        err
+      });
+    }
+  }
+
+  /**
+   * Remove documents from MongoDB matching query
+   *
+   * @param collection String identifier for collection documents belong to
+   * @param query key/value pairs of search conditions
+   *
+   * @returns Returns true for successful delete
+   *
+   * @example `deleteMany('123456', 'collectionName', { ident: 'generated-slug' })`
+   */
+  public async deleteMany(userId: string, collection: string, query: any) {
+    try {
+      this.verifyConnection();
+
+      const resp = await this._db.collection(collection).deleteMany(query);
+
+      if (resp.result.ok !== 1) {
+        throw new Error(JSON.stringify(resp));
+      }
+
+      this._loggerService.log('verbose', `Deleted documents from ${collection}`, {
+        userId,
+        collection,
+        query,
+        resp
+      });
+
+      return true;
+    } catch (err) {
+      this._loggerService.log('error', 'Could not delete documents', {
+        userId,
+        collection,
+        query,
+        err
+      });
+
+      return false
+    }
+  }
+
+  private verifyConnection() {
+    if (!this._mongoClient.isConnected) {
+      this._loggerService.log('error', 'No database connection available');
+      throw new Error('No database connection available');
+    }
+  }
+}

--- a/src/core/types/Config.ts
+++ b/src/core/types/Config.ts
@@ -5,6 +5,7 @@ export default interface Config {
   BOT_TRIGGER: string;
   DISCORD_BOT_TOKEN: string;
   MONGODB_URI: string;
+  MONGODB_DB_NAME: string;
   ENVIRONMENT: Environment;
   LOG_LEVEL: LogLevel;
 }

--- a/src/core/types/Config.ts
+++ b/src/core/types/Config.ts
@@ -4,6 +4,7 @@ import Environment from "./Environment";
 export default interface Config {
   BOT_TRIGGER: string;
   DISCORD_BOT_TOKEN: string;
+  MONGODB_URI: string;
   ENVIRONMENT: Environment;
   LOG_LEVEL: LogLevel;
 }

--- a/src/inversity.config.ts
+++ b/src/inversity.config.ts
@@ -2,9 +2,11 @@ import { Container } from "inversify";
 
 import ConfigService from "./core/services/config.service";
 import LoggerService from "./core/services/logger.service";
+import MongoService from "./core/services/mongo.service";
 
 const container = new Container();
 container.bind<ConfigService>(ConfigService).toSelf();
 container.bind<LoggerService>(LoggerService).toSelf();
+container.bind<MongoService>(MongoService).toSelf();
 
 export default container;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,25 @@ const app = new App();
 
 try {
   app.init();
+
+  function exitHandler() {
+    // Cleans up the application
+    app.exit();
+    exit();
+  }
+
+  // do something when app is closing
+  process.on('exit', exitHandler);
+
+  //catches ctrl+c event
+  process.on('SIGINT', exitHandler);
+
+  // catches "kill pid" (for example: nodemon restart)
+  process.on('SIGUSR1', exitHandler);
+  process.on('SIGUSR2', exitHandler);
+
+  //catches uncaught exceptions
+  process.on('uncaughtException', exitHandler);
 } catch (e) {
   exit(1);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,20 +82,12 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/mongodb@*":
+"@types/mongodb@~3.5.25":
   version "3.5.25"
   resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.5.25.tgz#ab187db04d79f8e3f15af236327dc9139d9d4736"
   integrity sha512-2H/Owt+pHCl9YmBOYnXc3VdnxejJEjVdH+QCWL5ZAfPehEn3evygKBX3/vKRv7aTwfNbUd0E5vjJdQklH/9a6w==
   dependencies:
     "@types/bson" "*"
-    "@types/node" "*"
-
-"@types/mongoose@~5.7.36":
-  version "5.7.36"
-  resolved "https://registry.yarnpkg.com/@types/mongoose/-/mongoose-5.7.36.tgz#2dae28c63041c6afba8a83ea02969f463b3f1021"
-  integrity sha512-ggFXgvkHgCNlT35B9d/heDYfSqOSwTmQjkRoR32sObGV5Xjd0N0WWuYlLzqeCg94j4hYN/OZxZ1VNNLltX/IVQ==
-  dependencies:
-    "@types/mongodb" "*"
     "@types/node" "*"
 
 "@types/node@*", "@types/node@~14.0.27":
@@ -201,11 +193,6 @@ bl@^2.2.0:
   dependencies:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
-
-bluebird@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-  integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
 boxen@^4.2.0:
   version "4.2.0"
@@ -409,13 +396,6 @@ crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
-
-debug@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
 
 debug@^2.2.0:
   version "2.6.9"
@@ -802,11 +782,6 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-kareem@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.1.tgz#def12d9c941017fabfb00f873af95e9c99e1be87"
-  integrity sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==
-
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -900,10 +875,10 @@ mkdirp@^0.5.3:
   dependencies:
     minimist "^1.2.5"
 
-mongodb@3.5.10:
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.5.10.tgz#ed414988d2935b529004cead6dfdd22681258887"
-  integrity sha512-p/C48UvTU/dr/PQEDKfb9DsCVDJWXGmdJNFC+u5FPmTQVtog69X6D8vrWHz+sJx1zJnd96sjdh9ueo7bx2ILTw==
+mongodb@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.0.tgz#babd7172ec717e2ed3f85e079b3f1aa29dce4724"
+  integrity sha512-/XWWub1mHZVoqEsUppE0GV7u9kanLvHxho6EvBxQbShXTKYF9trhZC2NzbulRGeG7xMJHD8IOWRcdKx5LPjAjQ==
   dependencies:
     bl "^2.2.0"
     bson "^1.1.4"
@@ -913,50 +888,12 @@ mongodb@3.5.10:
   optionalDependencies:
     saslprep "^1.0.0"
 
-mongoose-legacy-pluralize@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
-  integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
-
-mongoose@~5.9.28:
-  version "5.9.28"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.9.28.tgz#07064fbbc224d7fc4616ce82b7ada0e8df788e9c"
-  integrity sha512-A8lNRk4eCQDzk+DagSMYdH94LAYrbTK83LgrUlzqdig3YXvizW3DApJqOWQ5DdhuimvsfiD0Z5NTVzXl/rgi2w==
-  dependencies:
-    bson "^1.1.4"
-    kareem "2.3.1"
-    mongodb "3.5.10"
-    mongoose-legacy-pluralize "1.0.2"
-    mpath "0.7.0"
-    mquery "3.2.2"
-    ms "2.1.2"
-    regexp-clone "1.0.0"
-    safe-buffer "5.2.1"
-    sift "7.0.1"
-    sliced "1.0.1"
-
-mpath@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.7.0.tgz#20e8102e276b71709d6e07e9f8d4d0f641afbfb8"
-  integrity sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg==
-
-mquery@3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.2.2.tgz#e1383a3951852ce23e37f619a9b350f1fb3664e7"
-  integrity sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==
-  dependencies:
-    bluebird "3.5.1"
-    debug "3.1.0"
-    regexp-clone "^1.0.0"
-    safe-buffer "5.1.2"
-    sliced "1.0.1"
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.2, ms@^2.1.1:
+ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -1127,11 +1064,6 @@ reflect-metadata@~0.1.13:
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
-regexp-clone@1.0.0, regexp-clone@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-1.0.0.tgz#222db967623277056260b992626354a04ce9bf63"
-  integrity sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==
-
 registry-auth-token@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.0.tgz#1d37dffda72bbecd0f581e4715540213a65eb7da"
@@ -1173,15 +1105,15 @@ responselike@^1.0.2:
   dependencies:
     lowercase-keys "^1.0.0"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@5.2.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 saslprep@^1.0.0:
   version "1.0.3"
@@ -1212,11 +1144,6 @@ setimmediate@^1.0.5:
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
-sift@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/sift/-/sift-7.0.1.tgz#47d62c50b159d316f1372f8b53f9c10cd21a4b08"
-  integrity sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==
-
 signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
@@ -1228,11 +1155,6 @@ simple-swizzle@^0.2.2:
   integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
   dependencies:
     is-arrayish "^0.3.1"
-
-sliced@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/sliced/-/sliced-1.0.1.tgz#0b3a662b5d04c3177b1926bea82b03f837a2ef41"
-  integrity sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=
 
 source-map-support@^0.5.17:
   version "0.5.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,6 +58,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/bson@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/bson/-/bson-4.0.2.tgz#7accb85942fc39bbdb7515d4de437c04f698115f"
+  integrity sha512-+uWmsejEHfmSjyyM/LkrP0orfE2m5Mx9Xel4tXNeqi1ldK5XMQcDsFkBmLDtuyKUbxj2jGDo0H240fbCRJZo7Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -75,7 +82,23 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/node@~14.0.27":
+"@types/mongodb@*":
+  version "3.5.25"
+  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.5.25.tgz#ab187db04d79f8e3f15af236327dc9139d9d4736"
+  integrity sha512-2H/Owt+pHCl9YmBOYnXc3VdnxejJEjVdH+QCWL5ZAfPehEn3evygKBX3/vKRv7aTwfNbUd0E5vjJdQklH/9a6w==
+  dependencies:
+    "@types/bson" "*"
+    "@types/node" "*"
+
+"@types/mongoose@~5.7.36":
+  version "5.7.36"
+  resolved "https://registry.yarnpkg.com/@types/mongoose/-/mongoose-5.7.36.tgz#2dae28c63041c6afba8a83ea02969f463b3f1021"
+  integrity sha512-ggFXgvkHgCNlT35B9d/heDYfSqOSwTmQjkRoR32sObGV5Xjd0N0WWuYlLzqeCg94j4hYN/OZxZ1VNNLltX/IVQ==
+  dependencies:
+    "@types/mongodb" "*"
+    "@types/node" "*"
+
+"@types/node@*", "@types/node@~14.0.27":
   version "14.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
   integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
@@ -171,6 +194,19 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
+bl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.0.tgz#e1a574cdf528e4053019bb800b041c0ac88da493"
+  integrity sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
+bluebird@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+  integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
+
 boxen@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz#e411b62357d6d6d36587c8ac3d5d974daa070e64"
@@ -199,6 +235,11 @@ braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+bson@^1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.5.tgz#2aaae98fcdf6750c0848b0cba1ddec3c73060a34"
+  integrity sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -369,6 +410,13 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+debug@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.2.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -404,6 +452,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+denque@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
+  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -749,6 +802,11 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+kareem@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.1.tgz#def12d9c941017fabfb00f873af95e9c99e1be87"
+  integrity sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -801,6 +859,11 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
+memory-pager@^1.0.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
+  integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
+
 mime-db@1.44.0:
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
@@ -837,12 +900,63 @@ mkdirp@^0.5.3:
   dependencies:
     minimist "^1.2.5"
 
+mongodb@3.5.10:
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.5.10.tgz#ed414988d2935b529004cead6dfdd22681258887"
+  integrity sha512-p/C48UvTU/dr/PQEDKfb9DsCVDJWXGmdJNFC+u5FPmTQVtog69X6D8vrWHz+sJx1zJnd96sjdh9ueo7bx2ILTw==
+  dependencies:
+    bl "^2.2.0"
+    bson "^1.1.4"
+    denque "^1.4.1"
+    require_optional "^1.0.1"
+    safe-buffer "^5.1.2"
+  optionalDependencies:
+    saslprep "^1.0.0"
+
+mongoose-legacy-pluralize@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
+  integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
+
+mongoose@~5.9.28:
+  version "5.9.28"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.9.28.tgz#07064fbbc224d7fc4616ce82b7ada0e8df788e9c"
+  integrity sha512-A8lNRk4eCQDzk+DagSMYdH94LAYrbTK83LgrUlzqdig3YXvizW3DApJqOWQ5DdhuimvsfiD0Z5NTVzXl/rgi2w==
+  dependencies:
+    bson "^1.1.4"
+    kareem "2.3.1"
+    mongodb "3.5.10"
+    mongoose-legacy-pluralize "1.0.2"
+    mpath "0.7.0"
+    mquery "3.2.2"
+    ms "2.1.2"
+    regexp-clone "1.0.0"
+    safe-buffer "5.2.1"
+    sift "7.0.1"
+    sliced "1.0.1"
+
+mpath@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.7.0.tgz#20e8102e276b71709d6e07e9f8d4d0f641afbfb8"
+  integrity sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg==
+
+mquery@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.2.2.tgz#e1383a3951852ce23e37f619a9b350f1fb3664e7"
+  integrity sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==
+  dependencies:
+    bluebird "3.5.1"
+    debug "3.1.0"
+    regexp-clone "^1.0.0"
+    safe-buffer "5.1.2"
+    sliced "1.0.1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -979,7 +1093,7 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-readable-stream@^2.3.7:
+readable-stream@^2.3.5, readable-stream@^2.3.7:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -1013,6 +1127,11 @@ reflect-metadata@~0.1.13:
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
+regexp-clone@1.0.0, regexp-clone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-1.0.0.tgz#222db967623277056260b992626354a04ce9bf63"
+  integrity sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==
+
 registry-auth-token@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.0.tgz#1d37dffda72bbecd0f581e4715540213a65eb7da"
@@ -1026,6 +1145,19 @@ registry-url@^5.0.0:
   integrity sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==
   dependencies:
     rc "^1.2.8"
+
+require_optional@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
+  integrity sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==
+  dependencies:
+    resolve-from "^2.0.0"
+    semver "^5.1.0"
+
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+  integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
 
 resolve@^1.3.2:
   version "1.17.0"
@@ -1041,15 +1173,22 @@ responselike@^1.0.2:
   dependencies:
     lowercase-keys "^1.0.0"
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+saslprep@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.3.tgz#4c02f946b56cf54297e347ba1093e7acac4cf226"
+  integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
+  dependencies:
+    sparse-bitfield "^3.0.3"
 
 semver-diff@^3.1.1:
   version "3.1.1"
@@ -1058,7 +1197,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-semver@^5.3.0, semver@^5.7.1:
+semver@^5.1.0, semver@^5.3.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -1073,6 +1212,11 @@ setimmediate@^1.0.5:
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
+sift@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-7.0.1.tgz#47d62c50b159d316f1372f8b53f9c10cd21a4b08"
+  integrity sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==
+
 signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
@@ -1084,6 +1228,11 @@ simple-swizzle@^0.2.2:
   integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
   dependencies:
     is-arrayish "^0.3.1"
+
+sliced@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sliced/-/sliced-1.0.1.tgz#0b3a662b5d04c3177b1926bea82b03f837a2ef41"
+  integrity sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=
 
 source-map-support@^0.5.17:
   version "0.5.19"
@@ -1097,6 +1246,13 @@ source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sparse-bitfield@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
+  integrity sha1-/0rm5oZWBWuks+eSqzM004JzyhE=
+  dependencies:
+    memory-pager "^1.0.2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
## Context

Allowing the bot to store its own data will help make better commands.

## Description

- Adds a MongoDB connection to the bot. Connects on start and provides full CRUD.
- Each database command must also receive the user id that triggers the command, as a type of audit log.
- Adds new command that allows user to add messages to a 'greetings' collection. But does not have the server greeting use this data yet.

## Examples

```
findOne('123456', 'collectionName', { ident: 'generated-slug' })
find('123456', 'collectionName', { key: 'value' })
insert('123456', 'collectionName', [{ body: 'This is a document!' }])
updateMany('123456', 'collectionName', { ident: 'generated-slug' }, { secondKey: 'new data'})
deleteMany('123456', 'collectionName', { ident: 'generated-slug' })
```

## Testing

- [x] Manual