### PR TITLE
fix: message cast lowercase to try equal command prefix (also lowercase)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -42,7 +42,7 @@ export default class App {
       const prefix = this._configService.get('BOT_TRIGGER');
 
       // If the message either doesn't start with the prefix or was sent by a bot, exit early.
-      if (!message.content.startsWith(prefix) || message.author.bot) return;
+      if (!message.content.toLowerCase().startsWith(prefix.toLowerCase()) || message.author.bot) return;
 
       const args = message.content.slice(prefix.length).trim().split(/ +/);
       const commandName = args.shift().toLowerCase();


### PR DESCRIPTION
## Context

[GitHub Ticket](https://github.com/jondeaves/venom/issues/17)

## Description

Lowercases incoming message and the command prefix to ensure some sort of equality. The message is only lowercase'd to compare but remains intact for the rest of the sequence.

## Dependencies

None

## Testing

- [x] Manual / unit testing
